### PR TITLE
Digest Auth option

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ async def run(websession):
             host="192.168.1.69",
             username="username",
             password="password",
+            # auth_method="digest", # default: "basic"
             # protocol="https", # default: "http"
             # ssl_verify=True, # default: False
         ),
@@ -48,4 +49,5 @@ async def run(websession):
 asyncio.run(main())
 ```
 
+`auth_method` controls HTTP auth scheme and supports `"basic"` (default) and `"digest"`. Digest auth relies on `aiohttp.DigestAuthMiddleware`. 2N recommends Digest Auth, especially if using plain HTTP instead of HTTPS.
 `ssl_verify` controls TLS certificate verification for HTTPS connections. Requires the device to present a trusted server certificate (e.g. Let's Encrypt).

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ async def run(websession):
             host="192.168.1.69",
             username="username",
             password="password",
+            # protocol="https", # default: "http"
+            # ssl_verify=True, # default: False
         ),
     )
 
@@ -45,3 +47,5 @@ async def run(websession):
 
 asyncio.run(main())
 ```
+
+`ssl_verify` controls TLS certificate verification for HTTPS connections. Requires the device to present a trusted server certificate (e.g. Let's Encrypt).

--- a/py2n/model.py
+++ b/py2n/model.py
@@ -16,6 +16,7 @@ class Py2NConnectionData:
     password: str | None = None
     auth: aiohttp.BasicAuth | None = None
     protocol: str | None = "http"
+    ssl_verify: bool = False
     unprivileged: bool | None = False
 
     def __post_init__(self) -> None:

--- a/py2n/utils.py
+++ b/py2n/utils.py
@@ -311,10 +311,17 @@ async def api_request(
         endpoint="api/"+endpoint
 
     url=f"{options.protocol}://{options.host}/{endpoint}"
+    request_kwargs = {
+        "timeout": timeout,
+        "auth": options.auth,
+        "data": data,
+        "json": json,
+    }
+    if (options.protocol or "").lower() == "https":
+        request_kwargs["ssl"] = options.ssl_verify
+
     try:
-        response = await aiohttp_session.request(method,
-            url, timeout=timeout, auth=options.auth, ssl=False, data=data, json=json
-        )
+        response = await aiohttp_session.request(method, url, **request_kwargs)
         if response.content_type != CONTENT_TYPE:
             raise DeviceUnsupportedError(f"invalid content type: {response.content_type}")
 

--- a/py2n/utils.py
+++ b/py2n/utils.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import logging
 import aiohttp
 import asyncio
-
 from typing import Any, List
 
 from .const import (
@@ -313,10 +312,13 @@ async def api_request(
     url=f"{options.protocol}://{options.host}/{endpoint}"
     request_kwargs = {
         "timeout": timeout,
-        "auth": options.auth,
         "data": data,
         "json": json,
     }
+    if options.auth is not None:
+        request_kwargs["auth"] = options.auth
+    if options.auth_method == "digest" and options.digest_auth_middleware is not None:
+        request_kwargs["middlewares"] = (options.digest_auth_middleware,)
     if (options.protocol or "").lower() == "https":
         request_kwargs["ssl"] = options.ssl_verify
 
@@ -339,9 +341,10 @@ async def api_request(
     if not result["success"]:
         _LOGGER.debug("host %s: api unsuccessful: %r", options.host, result)
         code = result["error"]["code"]
+        has_credentials = options.username is not None and options.password is not None
         try:
             error = ApiError(code)
-            if error == ApiError.INSUFFICIENT_PRIVILEGES and not options.auth:
+            if error == ApiError.INSUFFICIENT_PRIVILEGES and not has_credentials:
                 error = ApiError.AUTHORIZATION_REQUIRED
 
             err = DeviceApiError(error)


### PR DESCRIPTION
Hi @linusgke ,
thanks for this awesome library enabling the Home Assistant integration!

With this PR I would like to add support for Digest Auth as an alternative to Basic Auth.
Additionally I introduced a flag to enable SSL certificate validation.

The code raises an exception if Digest Auth is selected but not supported by the installed `aiohttp` library. This way the library can be used with older versions if Digest Auth is not needed. Alternatively the requirement for `aiohttp` could be raised to at least `>=3.12.0` ([first introduction of `DigestAuthMiddleware`](https://docs.aiohttp.org/en/stable/changes.html#id49)).

Tested with 2N Access Units 2.0 with latest Firmware (3.0.2.76.4).

I would greatly appreciate your feedback!

Thanks and best regards,
Moritz

@cbergmann because you were interested in Digest Auth and contributed significantly to simplification of this code ;)