### PR TITLE
fix handling of switches

### DIFF
--- a/py2n/__init__.py
+++ b/py2n/__init__.py
@@ -20,7 +20,7 @@ from .utils import (
     restart,
     test_audio,
     get_switches,
-    get_switch_caps,
+    get_switch_status,
     set_switch,
     get_ports,
     get_port_status,
@@ -83,25 +83,7 @@ class Py2NDevice:
             else:
                 ports = await get_ports(self.aiohttp_session, self.options)
                 uptime = await self._get_uptime()
-                switch_caps: List[Any] = await get_switch_caps(self.aiohttp_session, self.options)
-                switches: List[Any] = await get_switches(self.aiohttp_session, self.options)
-                for switch in switches:
-                    if switch['active']:
-                        for caps in switch_caps:
-                            if caps["switch"] == switch["switch"]:
-                                enabled = caps["enabled"]
-                                mode = caps["mode"] if enabled else None
-                                break
-                        pySwitches.append(
-                            Py2NDeviceSwitch(
-                                id= switch["switch"],
-                                enabled= enabled,
-                                active= switch["active"],
-                                locked=switch["locked"],
-                                mode=mode,
-                            )
-                        )
-
+                pySwitches = await get_switches(self.aiohttp_session, self.options)
 
             self._data = Py2NDeviceData(
                 name=info["deviceName"],
@@ -121,7 +103,7 @@ class Py2NDevice:
             raise
 
     async def update_switch_status(self) -> None:
-        statuses = await get_switches(self.aiohttp_session, self.options)
+        statuses = await get_switch_status(self.aiohttp_session, self.options)
         for switch_status in statuses:
             for switch in self._data.switches:
                 if switch.id == switch_status["switch"]:


### PR DESCRIPTION
Hi,

I think I stumbled on a small bug in the implementation of "switches": In the current codebase those are only updated/considered if `switch["active"] == True`, meaning when they are switched on. I guess this was originally thought to check the `enabled` state and neglect all disabled switches.

I would propose to return all switches and let the calling code handle selection of the relevant ones.

I shifted the code block into `utils.py` to follow the same structure as for `ports`.

Please let me know your thoughts!
Best regards,
Moritz